### PR TITLE
there is no need to respond to a tap

### DIFF
--- a/src/Pullable.react.js
+++ b/src/Pullable.react.js
@@ -194,6 +194,12 @@ class Pullable extends PureComponent {
         }
     }
     _onShouldSetPanResponder(e, gesture, isOutside) {
+        // If we are just taping on an element, there is no need to use the PanResponder
+        if(gesture.dy == 0 && gesture.dx == 0)
+        {
+            return false;
+        }
+
         const { isOpen, childrenCanOpen } = this.state;
 
         const isClose = !isOpen;


### PR DESCRIPTION
The children in my pullable view represent a listview where each item is an accordion. If the pullable view is closed, I cannot click on the items in the accordion as the Panresponder is managing the touches. I think that we don't need to let the panresponder do any work if we have a tap dx && dy  = 0

That's more or less the same when the children are open -> there you don't let the panresponder do any work.